### PR TITLE
Don't hold mutex while Sleeping

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -101,13 +101,14 @@ func (c *mock) ResetSleep() Mock {
 }
 
 func (c *mock) Sleep(d time.Duration) {
-	defer c.sleepMutex.Unlock()
 	c.sleepMutex.Lock()
+	override := c.sleep
+	c.sleepMutex.Unlock()
 
-	if c.sleep == -1 {
+	if override == -1 {
 		time.Sleep(d)
 	} else {
-		time.Sleep(c.sleep)
+		time.Sleep(override)
 	}
 }
 


### PR DESCRIPTION
An example of the undesirable behaviour caused by sleeping while holding the mutex:

- goroutine A calls Sleep at time 0 seconds, with a duration of 30 seconds
- goroutine B calls Sleep at time 10 seconds, with a duration of 10 milliseconds.
- goroutine B tries to lock the mutex, but must wait until goroutine A is done its sleep
- goroutine A finishes sleeping, releases mutex. Releasing a mutex does not call the go scheduler, so A continues until a natural preemption point. If it doesn't have any natural preemption points before calling Sleep again, it will once again grab the mutex, which is still free and go to sleep again. This is a natural preemption point, so goroutine B wakes up, tries to lock the mutex, but again must wait for goroutine A to release it.
- Even in the event that goroutine A does hit a preemption point before calling Sleep again, goroutine B will have slept for at least 20 seconds more than it wanted to.