### PR TITLE
Add to frozen clock

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -49,7 +49,11 @@ func (c *mock) Add(d time.Duration) Mock {
 	c.timeMutex.Lock()
 
 	c.base = c.base.Add(d)
-	c.setAt = time.Now()
+	if c.frozen {
+		c.setAt = c.setAt.Add(d)
+	} else {
+		c.setAt = time.Now()
+	}
 	return c
 }
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,8 +1,8 @@
 package clock
 
 import (
-	"time"
 	. "github.com/101loops/bdd"
+	"time"
 )
 
 var (
@@ -25,8 +25,14 @@ var _ = Describe("Mock Clock", func() {
 		Check(clock.Now().Sub(fixedTime), IsRoughly, delay, threshold)
 	})
 
-	It("adds time", func() {
+	It("adds time when not frozen", func() {
 		clock := NewMock().Add(1 * time.Hour)
+		Check(timeDiff(clock), IsRoughly, -1*time.Hour, threshold)
+	})
+
+	It("adds time when frozen", func() {
+		clock := NewMock().Freeze()
+		clock.Add(1 * time.Hour)
 		Check(timeDiff(clock), IsRoughly, -1*time.Hour, threshold)
 	})
 

--- a/suite_test.go
+++ b/suite_test.go
@@ -1,9 +1,9 @@
 package clock
 
 import (
+	. "github.com/101loops/bdd"
 	"testing"
 	"time"
-	. "github.com/101loops/bdd"
 )
 
 var (


### PR DESCRIPTION
`clock.Freeze()` followed by `clock.Add(duration)` now adds `duration` to `clock`, rather than returning the time `Add()` was called.
